### PR TITLE
fix/send-with-cookies

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,7 +4,8 @@
     "browser": true,
     "node": true,
     "es6": true,
-    "mocha": true
+    "mocha": true,
+    "jest": true
   },
   "parserOptions": {
     "sourceType": "module",

--- a/spec/index.test.js
+++ b/spec/index.test.js
@@ -4,7 +4,11 @@ import sinonChai from 'sinon-chai'
 import chai, { expect } from 'chai'
 import { camelizeKeys, decamelizeKeys } from 'humps'
 
-import createApiMiddleware, { CALL_API, CHAIN_API } from '../src/index'
+import createApiMiddleware, {
+  CALL_API,
+  CHAIN_API,
+  paramsExtractor
+} from '../src'
 
 chai.use(sinonChai)
 
@@ -271,11 +275,10 @@ describe('Middleware::Api', ()=> {
         let promise = apiMiddleware({ dispatch, getState })(next)(action)
 
         promise.then(()=> {
-          expect(dispatch).to.have.been
-            .calledWith({
-              type: successType1,
-              response: camelizeKeys(response1)
-            })
+          expect(dispatch).to.have.been.calledWith({
+            type: successType1,
+            response: camelizeKeys(response1)
+          })
           nockScope.done()
           done()
         })
@@ -538,4 +541,22 @@ describe('Middleware::Api', ()=> {
     })
   })
 
+  describe('#paramsExtractor', () => {
+    let params
+    const baseUrl = 'http://base'
+    const callApi = {
+      path: '/path'
+    }
+    beforeEach(() => {
+      params = paramsExtractor({ baseUrl })(callApi)
+    })
+    it('sets `url` with prefix baseUrl', () => {
+      expect(params.url).to.equal(
+        `${baseUrl}${callApi.path}`
+      )
+    })
+    it('defaults to set withCredentials to ture', () => {
+      expect(params.withCredentials).to.equal(true)
+    })
+  })
 })

--- a/src/createRequestPromise.js
+++ b/src/createRequestPromise.js
@@ -66,6 +66,7 @@ export default function ({
           url: params.url,
           params: queryObject,
           data: sendObject,
+          withCredentials: params.withCredentials,
           timeout
         }, omitKeys))
         .then((res)=> {

--- a/src/index.js
+++ b/src/index.js
@@ -80,6 +80,7 @@ function paramsExtractor ({ baseUrl }) {
       url,
       camelizeResponse = true,
       decamelizeRequest = true,
+      withCredentials = true,
       successType,
       sendingType,
       errorType,
@@ -101,6 +102,7 @@ function paramsExtractor ({ baseUrl }) {
       afterSuccess,
       camelizeResponse,
       decamelizeRequest,
+      withCredentials,
       afterError
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -69,7 +69,7 @@ export default ({
   }
 }
 
-function paramsExtractor ({ baseUrl }) {
+export function paramsExtractor ({ baseUrl }) {
   return (callApi)=> {
     let {
       method,


### PR DESCRIPTION
default sets `withCredentials`. 
I think v1.5.0 (accidentally) changed this behavior?
https://github.com/CodementorIO/redux-api-middleman/commit/34911764aa9a351c2d261376f0adf853c366108a#diff-5f3e67ec357e7a821fab4d35b4096402