### PR TITLE
Feature/optimize bundle size

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "humps": "^1.1.0",
     "jest": "^21.2.1",
     "lodash": "^4.13.1",
+    "query-string": "^6.1.0",
     "yaku": "^0.18.6"
   },
   "licence": "MIT"

--- a/package.json
+++ b/package.json
@@ -43,10 +43,10 @@
   },
   "dependencies": {
     "axios": "^0.16.2",
-    "bluebird": "^3.4.0",
     "humps": "^1.1.0",
     "jest": "^21.2.1",
-    "lodash": "^4.13.1"
+    "lodash": "^4.13.1",
+    "yaku": "^0.18.6"
   },
   "licence": "MIT"
 }

--- a/spec/createRequestPromise.test.js
+++ b/spec/createRequestPromise.test.js
@@ -1,4 +1,4 @@
-import Promise from 'bluebird'
+import Promise from 'yaku/lib/yaku.core'
 import { CALL_API } from '../src'
 import createRequestPromise from '../src/createRequestPromise'
 import axios from 'axios'

--- a/src/createRequestPromise.js
+++ b/src/createRequestPromise.js
@@ -1,6 +1,6 @@
 
 import Promise from 'yaku/lib/yaku.core'
-import qs from 'qs'
+import qs from 'query-string'
 import _merge from 'lodash/merge'
 import _cloneDeep from 'lodash/cloneDeep'
 import _isFunction from 'lodash/isFunction'
@@ -147,7 +147,7 @@ export default function ({
         }
         return headersObject[contentTypeKey] === 'application/x-www-form-urlencoded'
       }
-      
+
       function generateBody ({ headersObject, sendObject }) {
         const isUrlencoded = isUrlencodedContentType(headersObject)
         return isUrlencoded ? qs.stringify(sendObject) : sendObject

--- a/src/createRequestPromise.js
+++ b/src/createRequestPromise.js
@@ -1,5 +1,5 @@
 
-import Promise from 'bluebird'
+import Promise from 'yaku/lib/yaku.core'
 import qs from 'qs'
 import _merge from 'lodash/merge'
 import _cloneDeep from 'lodash/cloneDeep'

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import Promise from 'bluebird'
+import Promise from 'yaku/lib/yaku.core'
 import createRequestPromise from './createRequestPromise'
 
 export const CALL_API = Symbol('CALL_API')

--- a/yarn.lock
+++ b/yarn.lock
@@ -970,7 +970,7 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
-bluebird@^3.4.0, bluebird@^3.5.1:
+bluebird@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
 
@@ -6635,6 +6635,10 @@ y18n@^3.2.1:
 y18n@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
+
+yaku@^0.18.6:
+  version "0.18.6"
+  resolved "https://registry.yarnpkg.com/yaku/-/yaku-0.18.6.tgz#3840096629774c5c0756a4105a545e441087f9da"
 
 yallist@^2.1.2:
   version "2.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5062,6 +5062,13 @@ query-string@^4.1.0:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
+query-string@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.1.0.tgz#01e7d69f6a0940dac67a937d6c6325647aa4532a"
+  dependencies:
+    decode-uri-component "^0.2.0"
+    strict-uri-encode "^2.0.0"
+
 querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -5882,6 +5889,10 @@ stream-shift@^1.0.0:
 strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
 
 string-length@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
- replace `bluebird` with `yaku`
- replace `qs` with `query-string`

### before
parsed: 126.9 kb 
gzipped: 36.5 kb

### after
parsed: 48 kb 
gzipped: 15.1 kb