### PR TITLE
add error payload as superagent

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ After the server responds fails, an action of type `errorType` would be dispatch
 The action would contain:
 
 - the key-val pairs other than `CALL_API` in the action object
-- an extra `error` key, with its value be the error object returned by [`superagent`](https://visionmedia.github.io/superagent/)
+- an extra `error` key, with its value be the error object returned by [`axios`](https://github.com/axios/axios)
 
 # LICENCE:
 MIT

--- a/spec/createRequestPromise.test.js
+++ b/spec/createRequestPromise.test.js
@@ -83,7 +83,7 @@ describe('createRequestPromise', () => {
   })
   it('should call axios with `data` key when method is `post`', () => {
     mockParams.method = 'post'
-    const promise = createRequestPromise({
+    createRequestPromise({
       timeout,
       generateDefaultParams,
       createCallApiAction,
@@ -107,7 +107,7 @@ describe('createRequestPromise', () => {
       }
     })
     extractParams.mockReturnValueOnce(Object.assign({}, params))
-    const promise = createRequestPromise({
+    createRequestPromise({
       timeout,
       generateDefaultParams,
       createCallApiAction,
@@ -132,7 +132,7 @@ describe('createRequestPromise', () => {
       }
     })
     extractParams.mockReturnValueOnce(Object.assign({}, params))
-    const promise = createRequestPromise({
+    createRequestPromise({
       timeout,
       generateDefaultParams,
       createCallApiAction,

--- a/src/createRequestPromise.js
+++ b/src/createRequestPromise.js
@@ -78,7 +78,7 @@ export default function ({
           resolve(resBody)
         })
         .catch((error)=> {
-          let err = error.response
+          let err = prepareErroPayload(error)
           function proceedError () {
             handleError(err)
           }
@@ -99,6 +99,20 @@ export default function ({
 
       }
       sendRequest()
+
+      function prepareErroPayload (error) {
+        let res = error.response || {}
+        let backwardCompatibleError = addResponseKeyAsSuperAgent(res)
+        return backwardCompatibleError
+      }
+
+      function addResponseKeyAsSuperAgent (res) {
+        return Object.assign({}, res, {
+          response: {
+            body: res.data
+          }
+        })
+      }
 
       function handleError (err) {
         dispatchErrorType(err)


### PR DESCRIPTION
after we changed to `axios`, the error structure has been changed... 🙈 