### PR TITLE
Passes error object to afterError callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ export function getInfo({ username }) {
       afterSuccess: ({ getState, dispatch, response }) => {
         //...
       },
-      afterError: ({ getState })=> {
+      afterError: ({ getState, error })=> {
         //...
       }
     }
@@ -242,7 +242,7 @@ This is a good place to handle request-related side effects such as route pushin
 
 ### afterError(optional):
 A callback function to be invoked after dispatching the action with type `errorType`.
-`({ getState })` would be passed into this callback function.
+`({ getState, error })` would be passed into this callback function.
 
 
 ## Sending Chaining Requests:

--- a/spec/index.test.js
+++ b/spec/index.test.js
@@ -387,7 +387,8 @@ describe('Middleware::Api', () => {
           error: expect.objectContaining({
             response: {
               body: errorPayload
-            }
+            },
+            data: errorPayload
           })
         })
       })

--- a/spec/index.test.js
+++ b/spec/index.test.js
@@ -383,7 +383,12 @@ describe('Middleware::Api', () => {
       it('trigger afterError of path2', async () => {
         await apiMiddleware({ dispatch, getState })(next)(action)
         expect(afterError2).toBeCalledWith({
-          getState
+          getState,
+          error: expect.objectContaining({
+            response: {
+              body: errorPayload
+            }
+          })
         })
       })
 

--- a/src/createRequestPromise.js
+++ b/src/createRequestPromise.js
@@ -107,7 +107,7 @@ export default function ({
 
       function handleError (err) {
         dispatchErrorType(err)
-        processAfterError()
+        processAfterError(err)
         reject(err)
       }
 
@@ -119,9 +119,9 @@ export default function ({
           }))
         }
       }
-      function processAfterError () {
+      function processAfterError (error) {
         if (_isFunction(params.afterError)) {
-          params.afterError({ getState })
+          params.afterError({ getState, error })
         }
       }
       function dispatchSuccessType (resBody) {


### PR DESCRIPTION
related issue https://github.com/CodementorIO/redux-api-middleman/issues/15
this add more flexibility to `afterError` callback

before
```js
afterError: ({ getState }) => {
  // can only do things with `getState`
}
```

after
```js
afterError: ({ getState, error }) => {
  // can also do things with `error`!
}
```