### PR TITLE
Feature/camelize error response

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-api-middleman",
-  "version": "2.0.2",
+  "version": "3.0.0-canary.0",
   "description": "A Redux middleware making sending request a breeze",
   "main": "lib/index.js",
   "jest": {
@@ -26,6 +26,7 @@
     "prebuild": "yarn clear",
     "build": "babel src --out-dir lib",
     "clear": "rm -rf lib/*",
+    "release:pre": "yarn build && release pre && npm publish",
     "release:patch": "yarn build && release patch && npm publish",
     "release:minor": "yarn build && release minor && npm publish",
     "release:major": "yarn build && release major && npm publish"

--- a/spec/createRequestPromise.test.js
+++ b/spec/createRequestPromise.test.js
@@ -8,13 +8,13 @@ jest.mock('axios')
 const getMockAxiosPromise = ({ error } = {}) => {
   return new Promise((resolve, reject) => {
     if (error) {
-      process.nextTick(() => reject({
+      process.nextTick(() => reject(new Error({
         response: {
           data: {
             key_1: 'val_1'
           },
         }
-      }))
+      })))
     } else {
       process.nextTick(() => resolve({
         data: {
@@ -160,22 +160,21 @@ describe('createRequestPromise', () => {
     beforeEach(() => {
       axios.mockReturnValue(getMockAxiosPromise({ error: true }))
     })
-    it('should call errorInterceptor', async () => {
+    it('should call errorInterceptor', () => {
       const errorInterceptor = jest.fn(({ proceedError }) => {
         proceedError()
       })
-      try {
-        await createRequestPromise({
-          timeout,
-          generateDefaultParams,
-          createCallApiAction,
-          getState,
-          dispatch,
-          errorInterceptor,
-          extractParams,
-          maxReplayTimes
-        })(mockPrevBody)
-      } catch (err) {
+      createRequestPromise({
+        timeout,
+        generateDefaultParams,
+        createCallApiAction,
+        getState,
+        dispatch,
+        errorInterceptor,
+        extractParams,
+        maxReplayTimes
+      })(mockPrevBody)
+      .catch(() => {
         expect(errorInterceptor).toHaveBeenCalledTimes(1)
         expect(errorInterceptor.mock.calls[0][0]).toMatchObject({
           err: {
@@ -185,7 +184,7 @@ describe('createRequestPromise', () => {
           },
           getState
         })
-      }
+      })
     })
   })
 })

--- a/spec/createRequestPromise.test.js
+++ b/spec/createRequestPromise.test.js
@@ -56,7 +56,6 @@ describe('createRequestPromise', () => {
     dispatch = jest.fn()
     getState = jest.fn()
     mockPrevBody = {}
-    console.log()
   })
   it('should return a Promise', () => {
     const promise = createRequestPromise({

--- a/spec/createRequestPromise.test.js
+++ b/spec/createRequestPromise.test.js
@@ -6,7 +6,7 @@ import axios from 'axios'
 jest.mock('axios')
 
 const getMockAxiosPromise = ({ error } = {}) => {
-  new Promise((resolve, reject) => {
+  return new Promise((resolve, reject) => {
     const res = {
       data: {
         key_1: 'val_1'
@@ -32,7 +32,7 @@ describe('createRequestPromise', () => {
   let dispatch
   let errorInterceptor
   let extractParams
-  let maxReplayTimes
+  let maxReplayTimes = 1
   let mockApiAction, mockParams, mockDefaultParams
   let mockPrevBody
   beforeEach(() => {
@@ -148,39 +148,5 @@ describe('createRequestPromise', () => {
     })(mockPrevBody)
     const firstArgument = getLastCall(axios)[0]
     expect(firstArgument.data).toEqual(body)
-  })
-
-  describe('when error occurs', () => {
-    beforeEach(() => {
-      axios.mockReturnValue(getMockAxiosPromise({ error: true }))
-    })
-    describe('errorInterceptor behavior', () => {
-      it('should be called with proceedError, err and getState', () => {
-        createRequestPromise({
-          timeout,
-          generateDefaultParams,
-          createCallApiAction,
-          getState,
-          dispatch,
-          errorInterceptor,
-          extractParams,
-          maxReplayTimes
-        })(mockPrevBody)
-      })
-      expect(errorInterceptor).toHaveBeenCalledTimes(1)
-      expect(errorInterceptor.mock.calls[0][0]).toMatchObject({
-        err: {
-          response: {
-            body: {
-              key_1: 'val_1'
-            }
-          }
-        },
-        getState
-      })
-    })
-    it('should return camelized payload if camelizeResponse is true', () => {
-
-    })
   })
 })

--- a/spec/index.test.js
+++ b/spec/index.test.js
@@ -385,10 +385,7 @@ describe('Middleware::Api', () => {
         expect(afterError2).toBeCalledWith({
           getState,
           error: expect.objectContaining({
-            response: {
-              body: errorPayload
-            },
-            data: errorPayload
+            data: camelizeKeys(errorPayload)
           })
         })
       })
@@ -410,8 +407,7 @@ describe('Middleware::Api', () => {
         }
         await apiMiddleware({ dispatch, getState })(next)(action)
         expect(dispatchedAction.type).toEqual(errorType2)
-        expect(dispatchedAction.error.data).toEqual(errorPayload)
-        expect(dispatchedAction.error.response.body).toEqual(errorPayload)
+        expect(dispatchedAction.error.data).toEqual(camelizeKeys(errorPayload))
       })
 
       describe('errorInterceptor behaviors', () => {

--- a/src/createRequestPromise.js
+++ b/src/createRequestPromise.js
@@ -98,12 +98,7 @@ export default function ({
       }
 
       function prepareErrorPayload ({ error, camelize }) {
-        let res
-        if (error.response) {
-          res = error.response
-        } else {
-          res = {}
-        }
+        let res = error.response || {}
         if (camelize) {
           res.data = camelizeKeys(res.data)
         }

--- a/src/createRequestPromise.js
+++ b/src/createRequestPromise.js
@@ -4,11 +4,7 @@ import omit from 'object.omit'
 import { camelizeKeys, decamelizeKeys } from 'humps'
 
 import { CALL_API } from './'
-import {
-  actionWith,
-  addResponseKeyAsSuperAgent,
-  generateBody
-} from './utils'
+import { actionWith, generateBody } from './utils'
 import log from './log'
 
 function isFunction (v) {
@@ -104,13 +100,14 @@ export default function ({
       function prepareErrorPayload ({ error, camelize }) {
         let res
         if (error.response) {
-          res = camelize ? camelizeKeys(error.response) : error.response
+          res = error.response
         } else {
           res = {}
         }
-        
-        const backwardCompatibleError = addResponseKeyAsSuperAgent({ res, camelize })
-        return backwardCompatibleError
+        if (camelize) {
+          res.data = camelizeKeys(res.data)
+        }
+        return res
       }
 
       function handleError (err) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,5 @@
 import qs from 'qs'
 import { CALL_API } from './'
-import { camelizeKeys } from 'humps'
 
 export const log = console
 
@@ -10,14 +9,6 @@ export function actionWith (action, toMerge) {
     ...extra,
     ...toMerge
   }
-}
-
-export function addResponseKeyAsSuperAgent ({ res, camelize }) {
-  return Object.assign({}, res, {
-    response: {
-      body: camelize ? camelizeKeys(res.data) : res.data
-    }
-  })
 }
 
 function _isUrlencodedContentType (headersObject) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,6 @@
 import qs from 'qs'
 import { CALL_API } from './'
+import { camelizeKeys } from 'humps'
 
 export const log = console
 
@@ -11,10 +12,10 @@ export function actionWith (action, toMerge) {
   }
 }
 
-export function addResponseKeyAsSuperAgent (res) {
+export function addResponseKeyAsSuperAgent ({ res, camelize }) {
   return Object.assign({}, res, {
     response: {
-      body: res.data
+      body: camelize ? camelizeKeys(res.data) : res.data
     }
   })
 }


### PR DESCRIPTION
closes #8 

- camelize error payload by default
- remove backward compatible error response handling (remove `response.body`)

TODO:
- [x] add more test for `createRequestPromise.js`