### PR TITLE
Pass dispatch to afterError callback

### DIFF
--- a/spec/createRequestPromise.test.js
+++ b/spec/createRequestPromise.test.js
@@ -174,17 +174,18 @@ describe('createRequestPromise', () => {
         extractParams,
         maxReplayTimes
       })(mockPrevBody)
-      .catch(() => {
-        expect(errorInterceptor).toHaveBeenCalledTimes(1)
-        expect(errorInterceptor.mock.calls[0][0]).toMatchObject({
-          err: {
-            data: {
-              key1: 'val_1'
-            }            
-          },
-          getState
+        .catch(() => {
+          expect(errorInterceptor).toHaveBeenCalledTimes(1)
+          expect(errorInterceptor.mock.calls[0][0]).toMatchObject({
+            err: {
+              data: {
+                key1: 'val_1'
+              }
+            },
+            dispatch,
+            getState
+          })
         })
-      })
     })
   })
 })

--- a/spec/index.test.js
+++ b/spec/index.test.js
@@ -384,6 +384,7 @@ describe('Middleware::Api', () => {
         await apiMiddleware({ dispatch, getState })(next)(action)
         expect(afterError2).toBeCalledWith({
           getState,
+          dispatch,
           error: expect.objectContaining({
             data: camelizeKeys(errorPayload)
           })

--- a/src/createRequestPromise.js
+++ b/src/createRequestPromise.js
@@ -121,7 +121,7 @@ export default function ({
       }
       function processAfterError (error) {
         if (isFunction(params.afterError)) {
-          params.afterError({ getState, error })
+          params.afterError({ getState, dispatch, error })
         }
       }
       function dispatchSuccessType (resBody) {


### PR DESCRIPTION
Same as what we did to `afterSuccess` to pass `dispatch` to afterError callback.
This will be used to fix an issue in cm-chat https://github.com/CodementorIO/cm-issues/issues/2125
It should dispatch an action to close the chatroom, if unable to get the chat info.