### PR TITLE
use es6-promise to replace yaku

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,10 +57,10 @@
   },
   "dependencies": {
     "axios": "^0.19.0",
+    "es6-promise": "^4.2.8",
     "humps": "^2.0.1",
     "object.omit": "^3.0.0",
-    "qs": "^6.5.2",
-    "yaku": "^0.19.3"
+    "qs": "^6.5.2"
   },
   "licence": "MIT"
 }

--- a/spec/createRequestPromise.test.js
+++ b/spec/createRequestPromise.test.js
@@ -1,4 +1,4 @@
-import Promise from 'yaku/lib/yaku.core'
+import Promise from 'es6-promise'
 import { CALL_API } from '../src'
 import createRequestPromise from '../src/createRequestPromise'
 import axios from 'axios'

--- a/src/createRequestPromise.js
+++ b/src/createRequestPromise.js
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import Promise from 'yaku/lib/yaku.core'
+import Promise from 'es6-promise'
 import omit from 'object.omit'
 import { camelizeKeys, decamelizeKeys } from 'humps'
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import Promise from 'yaku/lib/yaku.core'
+import Promise from 'es6-promise'
 import createRequestPromise from './createRequestPromise'
 import { paramsExtractor } from './utils'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2942,6 +2942,11 @@ es6-promise@^4.0.3:
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.6.tgz#b685edd8258886365ea62b57d30de28fadcd974f"
   integrity sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q==
 
+es6-promise@^4.2.8:
+  version "4.2.8"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a"
+  integrity sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==
+
 es6-promisify@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-5.0.0.tgz#5109d62f3e56ea967c4b63505aef08291c8a5203"
@@ -8634,11 +8639,6 @@ y18n@^3.2.0, y18n@^3.2.1:
 "y18n@^3.2.1 || ^4.0.0", y18n@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
-
-yaku@^0.19.3:
-  version "0.19.3"
-  resolved "https://registry.yarnpkg.com/yaku/-/yaku-0.19.3.tgz#886edda49b27ac98061bb8bdc7d56543c4dc61d1"
-  integrity sha512-QgelIZVBPKnWyvd/zoaSVOmv7lzLoa3gsjI+vjc9ts9QLeLCrWTSSHB6Y+Hslo+NntC5HelX/prt0Npt4B+pKA==
 
 yallist@^2.1.2:
   version "2.1.2"


### PR DESCRIPTION
## Why
the [implementation of yaku](https://github.com/ysmood/yaku/blob/master/src/yaku.core.js#L47) does not support `react-native` env very well. instead of [adding polyfill](https://stackoverflow.com/questions/34845760/process-nexttick-is-not-a-function-react-native-ddp-meteor) by ourselves, I'll prefer just use other mature solution.