### PR TITLE
Feature/forward axios config in error object

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     }
   ],
   "scripts": {
-    "test": "jest",
+    "test": "jest --watch --verbose false",
     "test:ci": "yarn lint && jest",
     "lint": "standard --fix --verbose | snazzy",
     "size": "size-limit",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-api-middleman",
-  "version": "3.2.2",
+  "version": "3.2.2-canary.0",
   "description": "A Redux middleware making sending request a breeze",
   "main": "lib/index.js",
   "jest": {

--- a/spec/createRequestPromise.test.js
+++ b/spec/createRequestPromise.test.js
@@ -1,5 +1,5 @@
 import Promise from 'es6-promise'
-import { CALL_API, CHAIN_API } from '../src'
+import { CALL_API } from '../src'
 import createRequestPromise from '../src/createRequestPromise'
 import axios from 'axios'
 import MockDate from 'mockdate'
@@ -11,20 +11,20 @@ jest.mock('../src/log')
 const getMockAxiosPromise = ({ error, config } = {}) => {
   return new Promise((resolve, reject) => {
     if (error) {
-      reject({
-        config,
-        response: {
-          data: {
-            key_1: 'val_1'
-          }
-        }
-      })
-    } else {
-      resolve({
+      const _error = new Error('Mock error')
+      _error.config = config
+      _error.response = {
         data: {
           key_1: 'val_1'
         }
-      })
+      }
+      process.nextTick(() => reject(_error))
+    } else {
+      process.nextTick(() => resolve({
+        data: {
+          key_1: 'val_1'
+        }
+      }))
     }
   })
 }
@@ -200,7 +200,7 @@ describe('createRequestPromise', () => {
 
   describe('revalidate behavior', () => {
     const currentime = 1579508700000
-    let path, testSetCount = 0
+    let path; let testSetCount = 0
 
     beforeEach(() => {
       testSetCount++
@@ -216,8 +216,8 @@ describe('createRequestPromise', () => {
       jest.clearAllMocks()
     })
 
-    function createRequest({ revalidate, revalidateDisabled } = {}){
-      extractParams = jest.fn().mockReturnValue({ ...mockParams, revalidate})
+    function createRequest ({ revalidate, revalidateDisabled } = {}) {
+      extractParams = jest.fn().mockReturnValue({ ...mockParams, revalidate })
       createRequestPromise({
         revalidateDisabled,
         timeout,

--- a/spec/index.test.js
+++ b/spec/index.test.js
@@ -7,9 +7,9 @@ import createApiMiddleware, {
   CHAIN_API
 } from '../src'
 
-const createRequestPromise = require('../src/createRequestPromise')
-
 import * as utils from '../src/utils'
+
+const createRequestPromise = require('../src/createRequestPromise')
 
 jest.mock('../src/log', () => ({
   error: jest.fn()
@@ -558,7 +558,7 @@ describe('Middleware::Api', () => {
     it('dispatches CHAIN_API with revalidateDisabled = true if action type is CALL_API', async () => {
       const action = { [CHAIN_API]: [
         () => ({ [CALL_API]: {} })
-      ]}
+      ] }
       await apiMiddleware({ dispatch, getState })(next)(action)
       expect(createRequestPromise.default.mock.calls[0][0].revalidateDisabled).toBe(true)
     })

--- a/src/createRequestPromise.js
+++ b/src/createRequestPromise.js
@@ -117,6 +117,7 @@ export default function ({
 
       function prepareErrorPayload ({ error, camelize }) {
         const res = error.response || {}
+        res.config = error.config
         if (camelize) {
           res.data = camelizeKeys(res.data)
         }

--- a/src/createRequestPromise.js
+++ b/src/createRequestPromise.js
@@ -165,19 +165,19 @@ export default function ({
   }
 }
 
-function _getRevalidationKey(actionObj) {
+function _getRevalidationKey (actionObj) {
   const {
     method,
     path,
     url,
     params,
-    data,
+    data
   } = actionObj
   return JSON.stringify({
     method,
     path,
     url,
     params,
-    data,
+    data
   })
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -70,4 +70,3 @@ export function paramsExtractor ({ baseUrl }) {
 const _window = typeof window === 'undefined' ? null : window
 
 export { _window as window }
-


### PR DESCRIPTION
We started to use the original request `config` (for axios) in error payload [recently](https://github.com/CodementorIO/cm-web/pull/1280). However, there're chances that the `config` will be lost in our error post-processing function, which resulted in [this exception](https://sentry.io/organizations/codementor/issues/2278039638).

changes:
- re-assign `config` to error payload in `prepareErrorPayload`
- fix tests